### PR TITLE
Backport core improvements from the downstream forks

### DIFF
--- a/application/commands/cache_purge.php
+++ b/application/commands/cache_purge.php
@@ -1,15 +1,18 @@
 <?php
 
+use core\Cache;
 use core\Command;
-use core\Path;
+use core\Template;
 
 class CachePurgeCommand extends Command
 {
     public function run(): int
     {
-        $cache = new Path('cache');
-        $cache->rmpath(true);
-        $cache->mkpath();
+        // Each store is cleared by the class that owns it. This used to rm -r the whole
+        // cache/ tree from outside, which happened to work but knew about the layout of two
+        // other classes and would have taken anything else stored there with it.
+        Cache::purge(Cache::CACHE_STATIC);
+        Template::purgeCaches();
 
         return 0;
     }

--- a/application/core/Cache.php
+++ b/application/core/Cache.php
@@ -99,14 +99,6 @@ final class Cache
     }
 
     /**
-     * Path of the file backing a static cache entry.
-     *
-     * This used to read new Path('cache/%s.tmp', $name). Path's second parameter is
-     * $validate, not a sprintf argument: the key was cast to a boolean, the %s was never
-     * substituted so every key shared one file, and the truthy $validate then made the
-     * constructor reject it as unreadable. Every CACHE_STATIC call threw.
-     */
-    /**
      * Classes that may be reconstructed from a cache entry.
      *
      * The wrapper this class stores is a stdClass, and that is all HCPHP itself puts in the
@@ -130,12 +122,79 @@ final class Cache
         return unserialize($serialized, ['allowed_classes' => self::UNSERIALIZE_ALLOWED_CLASSES]);
     }
 
+    /**
+     * Directory backing CACHE_STATIC.
+     *
+     * Template compiles into a subdirectory of this one, so purge() deletes files here and
+     * leaves directories alone.
+     */
+    const STATIC_CACHE_PATH = 'cache';
+
+    /**
+     * Drop every entry of one cache type.
+     *
+     * Entries could be written and removed one key at a time, but never cleared in bulk, so
+     * cache/ grew for the life of the install and invalidating it after a deploy meant rm on
+     * the server.
+     *
+     * Only the requested type is touched: the three are separate stores and a caller clearing
+     * its own request cache does not mean to log everyone out of a session cache.
+     *
+     * @param int $type
+     */
+    public static function purge(int $type = self::CACHE_REQUEST): void
+    {
+        if ($type == self::CACHE_SESSION) {
+            $_SESSION['cache'] = [];
+
+            return;
+        }
+
+        if ($type == self::CACHE_STATIC) {
+            $path = new Path(self::STATIC_CACHE_PATH);
+
+            // Nothing has been cached yet on a fresh checkout, and purging is a cleanup
+            // operation -- an absent directory is the desired end state, not an error.
+            $entries = is_dir((string)$path) ? scandir((string)$path) : false;
+
+            if ($entries === false) {
+                return;
+            }
+
+            foreach ($entries as $entry) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+
+                $file = new Path(sprintf('%s/%s', self::STATIC_CACHE_PATH, $entry));
+
+                // Subdirectories belong to whoever created them (cache/templates/ is
+                // Template's) and are cleared by their owner.
+                if (!is_dir((string)$file)) {
+                    $file->rmpath();
+                }
+            }
+
+            return;
+        }
+
+        self::$cache = [];
+    }
+
+    /**
+     * Path of the file backing a static cache entry.
+     *
+     * This used to read new Path('cache/%s.tmp', $name). Path's second parameter is
+     * $validate, not a sprintf argument: the key was cast to a boolean, the %s was never
+     * substituted so every key shared one file, and the truthy $validate then made the
+     * constructor reject it as unreadable. Every CACHE_STATIC call threw.
+     */
     private static function _getFile(string $name, bool $create = true): string
     {
         // A key is a name, not a path. Anything that could climb out of the cache directory
         // is flattened rather than trusted.
         $safeName = preg_replace('/[^A-Za-z0-9._-]+/', '_', $name);
-        $path = new Path(sprintf('cache/%s.tmp', $safeName));
+        $path = new Path(sprintf('%s/%s.tmp', self::STATIC_CACHE_PATH, $safeName));
 
         if ($create && !file_exists($path)) {
             $path->mkpath(true);
@@ -144,7 +203,7 @@ final class Cache
         return (string)$path;
     }
 
-    private static function _get(string $name, string $type = self::CACHE_REQUEST)
+    private static function _get(string $name, int $type = self::CACHE_REQUEST)
     {
         if ($type == self::CACHE_SESSION) {
             if (!empty($_SESSION['cache'][$name])) {

--- a/application/core/Cache.php
+++ b/application/core/Cache.php
@@ -28,7 +28,15 @@ final class Cache
      * Long term cache, global for all users
      */
     const CACHE_STATIC = 2;
-    
+
+    /**
+     * Directory backing CACHE_STATIC.
+     *
+     * Template compiles into a subdirectory of this one, so purge() deletes files here and
+     * leaves directories alone.
+     */
+    const STATIC_CACHE_PATH = 'cache';
+
     /**
      * Request cache
      *
@@ -121,14 +129,6 @@ final class Cache
     {
         return unserialize($serialized, ['allowed_classes' => self::UNSERIALIZE_ALLOWED_CLASSES]);
     }
-
-    /**
-     * Directory backing CACHE_STATIC.
-     *
-     * Template compiles into a subdirectory of this one, so purge() deletes files here and
-     * leaves directories alone.
-     */
-    const STATIC_CACHE_PATH = 'cache';
 
     /**
      * Drop every entry of one cache type.

--- a/application/core/Container.php
+++ b/application/core/Container.php
@@ -39,12 +39,12 @@ final class Container
      *
      * @return bool
      */
-    public function has($name): bool
+    public function has(string $name): bool
     {
         return $this->collection->offsetExists($name) || isset($this->factories[$name]);
     }
 
-    public function get($name)
+    public function get(string $name)
     {
         if ($this->collection->offsetExists($name)) {
             return $this->collection->offsetGet($name);
@@ -86,7 +86,7 @@ final class Container
         $this->factories[$name] = $factory;
     }
 
-    public function set($name, $object)
+    public function set(string $name, $object)
     {
         if (!is_object($object)) {
             throw new InvalidArgumentException(

--- a/application/core/Container.php
+++ b/application/core/Container.php
@@ -17,18 +17,73 @@ final class Container
      */
     private $collection;
 
+    /**
+     * Factories that have not been resolved yet, name => callable.
+     *
+     * An entry lives here until the service is first asked for; get() then runs it, stores
+     * the object in $collection and drops the factory. Nothing is ever in both.
+     *
+     * @var callable[]
+     */
+    private $factories = [];
+
     public function __construct()
     {
         $this->collection = new Collection();
     }
 
+    /**
+     * Whether $name can be resolved, without resolving it.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function has($name): bool
+    {
+        return $this->collection->offsetExists($name) || isset($this->factories[$name]);
+    }
+
     public function get($name)
     {
-        if (!$this->collection->offsetExists($name)) {
-            throw new InvalidArgumentException(sprintf('Object `%s` is not registered', $name));
+        if ($this->collection->offsetExists($name)) {
+            return $this->collection->offsetGet($name);
         }
 
-        return $this->collection->offsetGet($name);
+        if (isset($this->factories[$name])) {
+            $factory = $this->factories[$name];
+
+            // Dropped before it is invoked: a factory that asks for its own name then finds
+            // nothing registered and reports that, instead of recursing until the process
+            // runs out of stack.
+            unset($this->factories[$name]);
+
+            // set() validates the result, so a factory returning a non-object is rejected on
+            // the same terms as a direct set().
+            $this->set($name, $factory($this));
+
+            return $this->collection->offsetGet($name);
+        }
+
+        throw new InvalidArgumentException(sprintf('Object `%s` is not registered', $name));
+    }
+
+    /**
+     * Register a service to be built on first use.
+     *
+     * Init registers every service up front, and eagerly constructing them means a request
+     * that only renders a static page still opens a database connection. A factory defers
+     * that to the first get(); the result is stored and shared exactly like set().
+     *
+     * The factory receives this container, so it can resolve its own dependencies, and must
+     * return an object.
+     *
+     * @param string $name
+     * @param callable $factory
+     */
+    public function setFactory(string $name, callable $factory): void
+    {
+        $this->factories[$name] = $factory;
     }
 
     public function set($name, $object)

--- a/application/core/DatabaseSQL.php
+++ b/application/core/DatabaseSQL.php
@@ -28,6 +28,16 @@ class DatabaseSQL implements DatabaseInterface
     ];
 
     /**
+     * The server closed a connection that sat idle: the statement never reached it.
+     */
+    const ERROR_GONE_AWAY = 2006;
+
+    /**
+     * The connection died with the statement in flight: the server may already have run it.
+     */
+    const ERROR_LOST_DURING_QUERY = 2013;
+
+    /**
      * @var PDO
      */
     private $dbh;
@@ -285,7 +295,7 @@ class DatabaseSQL implements DatabaseInterface
         try {
             return $this->executeStatement($sql, $conditions);
         } catch (PDOException $exception) {
-            if (!$this->shouldReconnect($exception)) {
+            if (!$this->shouldReconnect($exception, $sql)) {
                 throw $exception;
             }
 
@@ -332,8 +342,10 @@ class DatabaseSQL implements DatabaseInterface
      *   risks repeating a user-visible action.
      * - Not inside a transaction. The transaction died with the connection, so replaying just
      *   this statement would commit a fragment of it.
+     * - Safe to replay. See isSafeToReplay(): a statement that may already have reached the
+     *   server is only repeated when repeating it cannot change anything.
      */
-    protected function shouldReconnect(PDOException $exception): bool
+    protected function shouldReconnect(PDOException $exception, string $sql): bool
     {
         if ($this->getDriver() !== self::DRIVER_MYSQL) {
             return false;
@@ -347,16 +359,60 @@ class DatabaseSQL implements DatabaseInterface
             return false;
         }
 
-        return self::isLostConnection($exception);
+        if (!self::isLostConnection($exception)) {
+            return false;
+        }
+
+        return self::isSafeToReplay($exception, $sql);
+    }
+
+    /**
+     * Whether running $sql a second time cannot repeat work the server already did.
+     *
+     * The two ways a connection dies are not equally safe to retry:
+     *
+     * - 2006, "server has gone away", is the server closing a connection that sat idle past
+     *   wait_timeout. The statement was never sent, so replaying it repeats nothing. This is
+     *   the case the reconnect exists for -- a CLI process that sleeps between units of work.
+     * - 2013, "lost connection during query", is the connection dying with the statement in
+     *   flight. The server may have executed it and failed only on the way back with the
+     *   answer. Replaying an INSERT there writes the row twice, and replaying
+     *   "SET n = n + 1" counts twice.
+     *
+     * So after 2013 only a read is repeated. The allow-list is deliberately short: anything
+     * unrecognised is treated as a write and simply not retried, which costs a failed run
+     * rather than duplicated data.
+     */
+    public static function isSafeToReplay(PDOException $exception, string $sql): bool
+    {
+        $driverCode = $exception->errorInfo[1] ?? 0;
+
+        if ($driverCode === self::ERROR_GONE_AWAY
+            || strpos($exception->getMessage(), 'server has gone away') !== false
+        ) {
+            return true;
+        }
+
+        return self::isReadOnly($sql);
+    }
+
+    /**
+     * Whether $sql only reads, and so may be run twice with no visible effect.
+     */
+    public static function isReadOnly(string $sql): bool
+    {
+        return (bool)preg_match('/^\s*\(?\s*(SELECT|SHOW|DESC(RIBE)?|EXPLAIN)\b/i', $sql);
     }
 
     /**
      * Whether a PDOException means the connection went away, as opposed to the statement
      * being wrong.
      *
-     * 2006 is "server has gone away", 2013 is "lost connection during query". The message is
-     * checked as well because the driver code is not always populated -- PDO leaves
-     * errorInfo[1] at 0 for some connection-level failures.
+     * This answers only "is the connection gone", not "may the statement be run again" --
+     * see isSafeToReplay() for that, which the two codes answer very differently.
+     *
+     * The message is checked as well because the driver code is not always populated -- PDO
+     * leaves errorInfo[1] at 0 for some connection-level failures.
      *
      * Deliberately not included: 1213 (deadlock) and 1205 (lock wait timeout). Both are
      * retryable in principle, but not by reconnecting -- the transaction they belonged to is
@@ -366,7 +422,7 @@ class DatabaseSQL implements DatabaseInterface
     {
         $driverCode = $exception->errorInfo[1] ?? 0;
 
-        if (in_array($driverCode, [2006, 2013], true)) {
+        if (in_array($driverCode, [self::ERROR_GONE_AWAY, self::ERROR_LOST_DURING_QUERY], true)) {
             return true;
         }
 

--- a/application/core/DatabaseSQL.php
+++ b/application/core/DatabaseSQL.php
@@ -299,16 +299,41 @@ class DatabaseSQL implements DatabaseInterface
                 throw $exception;
             }
 
-            // A CLI process that sleeps between units of work -- a cron task, an import, a
-            // queue worker -- outlives the server's idle timeout, and every query after that
-            // fails until the connection is rebuilt.
-            error_log(sprintf('[DatabaseSQL] connection lost, reconnecting: %s', $exception->getMessage()));
-
+            $this->logReconnect($exception);
             $this->connect();
 
             // Once only. If the second attempt fails too the connection is not coming back
             // and the caller has to hear about it.
             return $this->executeStatement($sql, $conditions);
+        }
+    }
+
+    /**
+     * Record that the connection was rebuilt.
+     *
+     * A CLI process that sleeps between units of work -- a cron task, an import, a queue
+     * worker -- outlives the server's idle timeout, and every query after that fails until
+     * the connection is rebuilt. A reconnect that leaves no trace turns a server dropping
+     * connections into an unexplained slowdown, so it goes to two places:
+     *
+     * - the server error log, because this is an operational event rather than a programming
+     *   mistake, and because it is the only record that survives with debug off -- which is
+     *   how production runs;
+     * - Debug, where every other framework message surfaces, so it is not the one event
+     *   missing from the output a developer is actually reading.
+     *
+     * Guarded by isOn(): Debug::dump() appends unconditionally while flush() only drains the
+     * buffer when debug is on, so dumping with it off would grow that buffer for the life of
+     * a long-running process -- exactly the process this reconnect exists for.
+     */
+    private function logReconnect(PDOException $exception): void
+    {
+        $message = sprintf('[DatabaseSQL] connection lost, reconnecting: %s', $exception->getMessage());
+
+        error_log($message);
+
+        if (Debug::isOn()) {
+            Debug::dump($message, false);
         }
     }
 

--- a/application/core/DatabaseSQL.php
+++ b/application/core/DatabaseSQL.php
@@ -28,12 +28,14 @@ class DatabaseSQL implements DatabaseInterface
     ];
 
     /**
-     * The server closed a connection that sat idle: the statement never reached it.
+     * "MySQL server has gone away". Reported both for a connection the server closed after
+     * wait_timeout and for one killed while a statement was running -- it says the connection
+     * is gone, not whether the statement ran.
      */
     const ERROR_GONE_AWAY = 2006;
 
     /**
-     * The connection died with the statement in flight: the server may already have run it.
+     * "Lost connection to MySQL server during query".
      */
     const ERROR_LOST_DURING_QUERY = 2013;
 
@@ -367,8 +369,8 @@ class DatabaseSQL implements DatabaseInterface
      *   risks repeating a user-visible action.
      * - Not inside a transaction. The transaction died with the connection, so replaying just
      *   this statement would commit a fragment of it.
-     * - Safe to replay. See isSafeToReplay(): a statement that may already have reached the
-     *   server is only repeated when repeating it cannot change anything.
+     * - A read. See isReadOnly(): the error does not say whether the server ran the statement,
+     *   so a write is never replayed.
      */
     protected function shouldReconnect(PDOException $exception, string $sql): bool
     {
@@ -388,41 +390,31 @@ class DatabaseSQL implements DatabaseInterface
             return false;
         }
 
-        return self::isSafeToReplay($exception, $sql);
-    }
-
-    /**
-     * Whether running $sql a second time cannot repeat work the server already did.
-     *
-     * The two ways a connection dies are not equally safe to retry:
-     *
-     * - 2006, "server has gone away", is the server closing a connection that sat idle past
-     *   wait_timeout. The statement was never sent, so replaying it repeats nothing. This is
-     *   the case the reconnect exists for -- a CLI process that sleeps between units of work.
-     * - 2013, "lost connection during query", is the connection dying with the statement in
-     *   flight. The server may have executed it and failed only on the way back with the
-     *   answer. Replaying an INSERT there writes the row twice, and replaying
-     *   "SET n = n + 1" counts twice.
-     *
-     * So after 2013 only a read is repeated. The allow-list is deliberately short: anything
-     * unrecognised is treated as a write and simply not retried, which costs a failed run
-     * rather than duplicated data.
-     */
-    public static function isSafeToReplay(PDOException $exception, string $sql): bool
-    {
-        $driverCode = $exception->errorInfo[1] ?? 0;
-
-        if ($driverCode === self::ERROR_GONE_AWAY
-            || strpos($exception->getMessage(), 'server has gone away') !== false
-        ) {
-            return true;
-        }
-
+        // Only a read. A write is never replayed, whatever the error says -- see isReadOnly().
         return self::isReadOnly($sql);
     }
 
     /**
-     * Whether $sql only reads, and so may be run twice with no visible effect.
+     * Whether $sql only reads, and so may be run a second time with no visible effect.
+     *
+     * This is the whole of the replay rule, because the error carries no usable information
+     * about whether the server ran the statement. Measured against MariaDB 11, not assumed:
+     *
+     * - A connection closed by the server after wait_timeout reports 2006, "server has gone
+     *   away". So does a connection killed while a statement had been executing for two
+     *   seconds -- same code, same message, for both reads and writes.
+     * - PDO's MySQL driver emulates prepares by default (ATTR_EMULATE_PREPARES = 1) and this
+     *   class never turns that off, so prepare() makes no server round-trip and the failure
+     *   always surfaces at execute() -- exactly where a statement that did reach the server
+     *   fails too.
+     *
+     * There is therefore no way to tell "never sent" from "sent, ran, and the answer was lost
+     * on the way back". Replaying an INSERT in the second case writes the row twice, and
+     * "SET n = n + 1" counts twice. A read replayed in either case is harmless.
+     *
+     * The allow-list is deliberately short: anything unrecognised counts as a write. A missed
+     * retry costs a failed run, which the caller sees; a wrong one costs duplicated data,
+     * which nobody sees.
      */
     public static function isReadOnly(string $sql): bool
     {
@@ -434,7 +426,8 @@ class DatabaseSQL implements DatabaseInterface
      * being wrong.
      *
      * This answers only "is the connection gone", not "may the statement be run again" --
-     * see isSafeToReplay() for that, which the two codes answer very differently.
+     * see isReadOnly() for that. Neither code distinguishes a statement that never reached
+     * the server from one that ran.
      *
      * The message is checked as well because the driver code is not always populated -- PDO
      * leaves errorInfo[1] at 0 for some connection-level failures.

--- a/application/core/DatabaseSQL.php
+++ b/application/core/DatabaseSQL.php
@@ -4,7 +4,9 @@ namespace core;
 
 use InvalidArgumentException;
 use PDO;
+use PDOException;
 use PDOStatement;
+use RuntimeException;
 
 /**
  * @package    hcphp
@@ -39,7 +41,32 @@ class DatabaseSQL implements DatabaseInterface
      * @var string Current driver name
      */
     private $driver;
-    
+
+    /**
+     * Connection details, kept so a dropped connection can be rebuilt.
+     *
+     * Null for sqlite: an in-memory database cannot be reconnected without discarding it, and
+     * a file one never drops. connect() refuses to run without a DSN.
+     *
+     * @var string|null
+     */
+    private $dsn;
+
+    /**
+     * @var string
+     */
+    private $user = '';
+
+    /**
+     * @var string
+     */
+    private $pass = '';
+
+    /**
+     * @var string
+     */
+    private $encoding = 'utf8';
+
     /**
      * @param string $driver Database type (sqlite, mysql, pgsql, mssql)
      * @param string|null $uri Resource (host, file or memory(if null))
@@ -60,6 +87,10 @@ class DatabaseSQL implements DatabaseInterface
         string $encoding = 'utf8',
         ?string $port = null
     ) {
+        $this->prefix = $prefix;
+        $this->driver = $driver;
+        $this->encoding = $encoding;
+
         if ($driver === self::DRIVER_SQLITE) {
             if ($uri === null) {
                 $path = ':memory:';
@@ -69,27 +100,38 @@ class DatabaseSQL implements DatabaseInterface
             }
 
             $this->dbh = new PDO(sprintf('sqlite:%s', $path));
+            $this->dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-        } else {
-            if ($port === null) {
-                $port = self::DEFAULT_PORTS[$driver];
-            }
-
-            $this->dbh = new PDO(
-                sprintf('%s:host=%s;port=%d;dbname=%s', $driver, $uri, $port, $dbname),
-                $user,
-                $pass
-            );
+            return;
         }
 
+        if ($port === null) {
+            $port = self::DEFAULT_PORTS[$driver];
+        }
+
+        $this->dsn = sprintf('%s:host=%s;port=%d;dbname=%s', $driver, $uri, $port, $dbname);
+        $this->user = $user;
+        $this->pass = $pass;
+
+        $this->connect();
+    }
+
+    /**
+     * Open the connection described by the constructor arguments.
+     *
+     * Called once from the constructor and again by execute() when a server-side connection
+     * has gone away. Everything that configures a handle belongs here, or the rebuilt one
+     * would come back with different settings from the original.
+     */
+    protected function connect(): void
+    {
+        if ($this->dsn === null) {
+            throw new RuntimeException('This connection cannot be re-established.');
+        }
+
+        $this->dbh = new PDO($this->dsn, $this->user, $this->pass);
         $this->dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-
-        if ($driver !== self::DRIVER_SQLITE) {
-            $this->dbh->exec(sprintf('SET NAMES %s', $encoding));
-        }
-
-        $this->prefix = $prefix;
-        $this->driver = $driver;
+        $this->dbh->exec(sprintf('SET NAMES %s', $this->encoding));
     }
 
     public function getDBH(): PDO
@@ -238,7 +280,34 @@ class DatabaseSQL implements DatabaseInterface
         return $sth->fetchAll(\PDO::FETCH_ASSOC);
     }
 
-    private function execute(string $sql, $conditions = [])
+    private function execute(string $sql, array $conditions = [])
+    {
+        try {
+            return $this->executeStatement($sql, $conditions);
+        } catch (PDOException $exception) {
+            if (!$this->shouldReconnect($exception)) {
+                throw $exception;
+            }
+
+            // A CLI process that sleeps between units of work -- a cron task, an import, a
+            // queue worker -- outlives the server's idle timeout, and every query after that
+            // fails until the connection is rebuilt.
+            error_log(sprintf('[DatabaseSQL] connection lost, reconnecting: %s', $exception->getMessage()));
+
+            $this->connect();
+
+            // Once only. If the second attempt fails too the connection is not coming back
+            // and the caller has to hear about it.
+            return $this->executeStatement($sql, $conditions);
+        }
+    }
+
+    /**
+     * Prepare, bind and run one statement.
+     *
+     * @throws PDOException
+     */
+    protected function executeStatement(string $sql, array $conditions = []): PDOStatement
     {
         $sth = $this->dbh->prepare($sql);
 
@@ -247,8 +316,64 @@ class DatabaseSQL implements DatabaseInterface
         }
 
         $sth->execute();
-        
+
         return $sth;
+    }
+
+    /**
+     * Whether $exception is worth retrying on a rebuilt connection.
+     *
+     * Every clause is a safety guard, not an optimisation:
+     *
+     * - MySQL only. sqlite has no server to lose and reconnecting an in-memory database would
+     *   silently discard it. The other drivers report connection loss differently and are not
+     *   verified here, so they are left alone rather than guessed at.
+     * - CLI only. In a web request a failed statement should surface; replaying it invisibly
+     *   risks repeating a user-visible action.
+     * - Not inside a transaction. The transaction died with the connection, so replaying just
+     *   this statement would commit a fragment of it.
+     */
+    protected function shouldReconnect(PDOException $exception): bool
+    {
+        if ($this->getDriver() !== self::DRIVER_MYSQL) {
+            return false;
+        }
+
+        if (Application::getMode() !== Application::MODE_CLI) {
+            return false;
+        }
+
+        if ($this->dbh->inTransaction()) {
+            return false;
+        }
+
+        return self::isLostConnection($exception);
+    }
+
+    /**
+     * Whether a PDOException means the connection went away, as opposed to the statement
+     * being wrong.
+     *
+     * 2006 is "server has gone away", 2013 is "lost connection during query". The message is
+     * checked as well because the driver code is not always populated -- PDO leaves
+     * errorInfo[1] at 0 for some connection-level failures.
+     *
+     * Deliberately not included: 1213 (deadlock) and 1205 (lock wait timeout). Both are
+     * retryable in principle, but not by reconnecting -- the transaction they belonged to is
+     * gone, and replaying one statement of it would be wrong.
+     */
+    public static function isLostConnection(PDOException $exception): bool
+    {
+        $driverCode = $exception->errorInfo[1] ?? 0;
+
+        if (in_array($driverCode, [2006, 2013], true)) {
+            return true;
+        }
+
+        $message = $exception->getMessage();
+
+        return strpos($message, 'server has gone away') !== false
+            || strpos($message, 'Lost connection') !== false;
     }
 
     public function executeSQL(string $sql, array $values = [])

--- a/application/core/Template.php
+++ b/application/core/Template.php
@@ -13,6 +13,14 @@ use stdClass;
  */
 class Template
 {
+    /**
+     * Where templates are compiled to.
+     *
+     * A subdirectory of Cache's static cache directory, so Cache::purge() steps over it and
+     * this class clears it instead.
+     */
+    const CACHE_PATH = 'cache/templates';
+
     protected $data = [];
     protected $path;
     protected $template;
@@ -108,11 +116,10 @@ class Template
      */
     public function make(?array $data = null)
     {
-        $cache = new Path(sprintf('/cache/templates/%s.tmp', $this->template));
+        $cache = new Path(sprintf('%s/%s.tmp', self::CACHE_PATH, $this->template));
 
         if (!(is_readable($cache) && filemtime($cache) > filemtime($this->path))) {
             $contents = file_get_contents($this->path);
-            $cache = new Path(sprintf('/cache/templates/%s.tmp', $this->template));
             $cache->mkpath();
 
             file_put_contents($cache, $this->parse($contents));
@@ -129,6 +136,27 @@ class Template
         include ($this->path);
 
         return ob_get_clean();
+    }
+
+    /**
+     * Drop every compiled template.
+     *
+     * make() recompiles only when the source is newer than the compiled copy, so a deploy
+     * that does not advance mtimes -- rsync without --times, a checkout onto a warm cache, an
+     * archive unpacked with preserved timestamps -- keeps serving the previous build. There
+     * was no way to force a recompile short of rm on the server.
+     *
+     * Recursive because template names carry slashes ('form/default'), so compiled files sit
+     * in subdirectories.
+     */
+    public static function purgeCaches(): void
+    {
+        $path = new Path(self::CACHE_PATH);
+
+        // Nothing compiled yet is the desired end state, not an error.
+        if (is_dir((string)$path)) {
+            $path->rmpath(true);
+        }
     }
 
     private function parse(string $contents)

--- a/application/events/Init.php
+++ b/application/events/Init.php
@@ -21,6 +21,14 @@ final class Init extends Handler
 {
     private $container;
 
+    /**
+     * Resolved once and reused by the two services that need it, so registering them stays
+     * free even though reading it is not.
+     *
+     * @var int|null
+     */
+    private $loginTime;
+
     public function __construct($data = null)
     {
         $this->container = Application::getContainer();
@@ -64,39 +72,78 @@ final class Init extends Handler
         return $database;
     }
 
+    /**
+     * The services below are registered as factories rather than built here.
+     *
+     * Every request used to construct all of them, whichever route it was headed for:
+     * TableRepository parses the DynamicDB config in its constructor, and a CLI command that
+     * only wants the user manager was still handed a ViewFactory and an Authenticator. They
+     * are plain constructions with no side effects, so deferring them changes nothing except
+     * when the work happens.
+     *
+     * The database stays eager: DatabaseManager::initialize() below needs a live connection
+     * during Init, so there is nothing to defer.
+     */
     private function initDynamicDB(DatabaseSQL $database)
     {
         (new DatabaseManager($database))->initialize();
 
-        $tableRepository = new TableRepository();
-        $this->container->set('repository_table', $tableRepository);
-        $this->container->set(
-            'factory_dynamic_repository',
-            new DynamicRepositoryFactory($database, $tableRepository)
-        );
+        $this->container->setFactory('repository_table', function () {
+            return new TableRepository();
+        });
+
+        $this->container->setFactory('factory_dynamic_repository', function ($container) use ($database) {
+            return new DynamicRepositoryFactory($database, $container->get('repository_table'));
+        });
     }
 
     private function initUserBundle(DatabaseInterface $database)
     {
-        $roleRepository = new RoleRepository(new RoleMapper());
-        $this->container->set('repository_role', $roleRepository);
+        $this->container->setFactory('repository_role', function () {
+            return new RoleRepository(new RoleMapper());
+        });
 
-        $userRepository = new UserRepository($database, new UserMapper($roleRepository));
-        $this->container->set('repository_user', $userRepository);
+        $this->container->setFactory('repository_user', function ($container) use ($database) {
+            return new UserRepository(
+                $database,
+                new UserMapper($container->get('repository_role'))
+            );
+        });
 
-        $userManager = new UserManager($userRepository, $roleRepository);
-        $this->container->set('user_manager', $userManager);
+        $this->container->setFactory('user_manager', function ($container) {
+            return new UserManager(
+                $container->get('repository_user'),
+                $container->get('repository_role')
+            );
+        });
 
-        // How long a login stays valid. This was configurable but nothing read it, so both
-        // services silently used their own default and an auth key never actually expired.
-        $config = new Config('default', ['loginTime' => Authenticator::DEFAULT_LOGIN_TIME]);
-        $loginTime = (int)$config->get('loginTime');
+        $this->container->setFactory('authenticator', function ($container) {
+            return new Authenticator($container->get('repository_user'), $this->getLoginTime());
+        });
 
-        $authChecker = new AuthChecker($userRepository, $loginTime);
+        $this->container->setFactory('auth_checker', function ($container) {
+            return new AuthChecker($container->get('repository_user'), $this->getLoginTime());
+        });
 
-        $this->container->set('authenticator', new Authenticator($userRepository, $loginTime));
-        $this->container->set('auth_checker', $authChecker);
-        $this->container->set('view_factory', new ViewFactory($authChecker));
+        $this->container->setFactory('view_factory', function ($container) {
+            return new ViewFactory($container->get('auth_checker'));
+        });
+    }
+
+    /**
+     * How long a login stays valid.
+     *
+     * This was configurable but nothing read it, so both services silently used their own
+     * default and an auth key never actually expired.
+     */
+    private function getLoginTime(): int
+    {
+        if ($this->loginTime === null) {
+            $config = new Config('default', ['loginTime' => Authenticator::DEFAULT_LOGIN_TIME]);
+            $this->loginTime = (int)$config->get('loginTime');
+        }
+
+        return $this->loginTime;
     }
 
     private function extendTemplates()

--- a/application/lib/RecordsQueryBuilder.php
+++ b/application/lib/RecordsQueryBuilder.php
@@ -40,6 +40,12 @@ class RecordsQueryBuilder implements QueryBuilderInterface
 
     public function getValues(): array
     {
+        // Must mirror getLike(): with no search term it emits no ":like" token, and binding a
+        // value the statement has no token for is an error, not a no-op.
+        if (empty($this->like)) {
+            return [];
+        }
+
         return [
             'like' => '%' . $this->like . '%',
         ];

--- a/tests/Unit/Core/CachePurgeTest.php
+++ b/tests/Unit/Core/CachePurgeTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Unit\Core;
+
+use core\Cache;
+use core\Path;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Cache could write CACHE_STATIC entries but never clear them in bulk: cache/ grew without
+ * bound and the only way to invalidate it was rm on the server.
+ *
+ * @covers \core\Cache
+ */
+class CachePurgeTest extends TestCase
+{
+    private const KEYS = ['alpha', 'beta', 'gamma'];
+
+    protected function setUp(): void
+    {
+        $_SESSION = [];
+        $this->removeAll();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeAll();
+        $_SESSION = [];
+
+        $templates = new Path('cache/templates');
+
+        if (is_dir((string)$templates)) {
+            $templates->rmpath(true);
+        }
+    }
+
+    private function removeAll(): void
+    {
+        foreach (self::KEYS as $key) {
+            Cache::remove($key, Cache::CACHE_REQUEST);
+            Cache::remove($key, Cache::CACHE_SESSION);
+            Cache::remove($key, Cache::CACHE_STATIC);
+        }
+    }
+
+    public function testPurgeClearsTheRequestCache(): void
+    {
+        Cache::set('alpha', 'value');
+        Cache::set('beta', 'value');
+
+        Cache::purge();
+
+        self::assertNull(Cache::get('alpha'));
+        self::assertNull(Cache::get('beta'));
+    }
+
+    public function testPurgeClearsTheSessionCache(): void
+    {
+        Cache::set('alpha', 'value', Cache::CACHE_SESSION);
+        Cache::set('beta', 'value', Cache::CACHE_SESSION);
+
+        Cache::purge(Cache::CACHE_SESSION);
+
+        self::assertNull(Cache::get('alpha', Cache::CACHE_SESSION));
+        self::assertNull(Cache::get('beta', Cache::CACHE_SESSION));
+    }
+
+    public function testPurgeClearsTheStaticCache(): void
+    {
+        Cache::set('alpha', 'value', Cache::CACHE_STATIC);
+        Cache::set('beta', 'value', Cache::CACHE_STATIC);
+
+        Cache::purge(Cache::CACHE_STATIC);
+
+        self::assertNull(Cache::get('alpha', Cache::CACHE_STATIC));
+        self::assertNull(Cache::get('beta', Cache::CACHE_STATIC));
+    }
+
+    public function testPurgeRemovesTheBackingFiles(): void
+    {
+        Cache::set('alpha', 'value', Cache::CACHE_STATIC);
+
+        self::assertNotSame([], glob((string)new Path('cache')) ? glob((string)new Path('cache') . '/*.tmp') : []);
+
+        Cache::purge(Cache::CACHE_STATIC);
+
+        self::assertSame([], glob((string)new Path('cache') . '/*.tmp'));
+    }
+
+    /**
+     * Compiled templates live in cache/templates/. Purging the static cache must not take
+     * them with it -- Template owns that directory and clears it separately.
+     */
+    public function testPurgingTheStaticCacheLeavesSubdirectoriesAlone(): void
+    {
+        // mkpath() creates the parent of the path it is given, so this is the marker file
+        // itself rather than the directory holding it.
+        $marker = new Path('cache/templates/marker.tmp');
+        $marker->mkpath();
+        file_put_contents((string)$marker, 'compiled');
+
+        Cache::set('alpha', 'value', Cache::CACHE_STATIC);
+        Cache::purge(Cache::CACHE_STATIC);
+
+        self::assertFileExists((string)$marker);
+        self::assertNull(Cache::get('alpha', Cache::CACHE_STATIC));
+    }
+
+    public function testPurgingOneTypeLeavesTheOthersIntact(): void
+    {
+        Cache::set('alpha', 'request value');
+        Cache::set('alpha', 'session value', Cache::CACHE_SESSION);
+        Cache::set('alpha', 'static value', Cache::CACHE_STATIC);
+
+        Cache::purge(Cache::CACHE_REQUEST);
+
+        self::assertNull(Cache::get('alpha'));
+        self::assertSame('session value', Cache::get('alpha', Cache::CACHE_SESSION));
+        self::assertSame('static value', Cache::get('alpha', Cache::CACHE_STATIC));
+    }
+
+    /**
+     * On a fresh checkout nothing has been cached yet, so cache/ may not exist. Purging is
+     * a cleanup operation and has nothing to complain about.
+     */
+    public function testPurgingAnAbsentStaticCacheDirectoryIsNotAnError(): void
+    {
+        $cache = new Path('cache');
+
+        if (is_dir((string)$cache)) {
+            $cache->rmpath(true);
+        }
+
+        Cache::purge(Cache::CACHE_STATIC);
+
+        self::assertNull(Cache::get('alpha', Cache::CACHE_STATIC));
+    }
+
+    public function testPurgingAnEmptySessionCacheIsNotAnError(): void
+    {
+        $_SESSION = [];
+
+        Cache::purge(Cache::CACHE_SESSION);
+
+        self::assertSame([], $_SESSION['cache']);
+    }
+}

--- a/tests/Unit/Core/CachePurgeTest.php
+++ b/tests/Unit/Core/CachePurgeTest.php
@@ -79,12 +79,19 @@ class CachePurgeTest extends TestCase
     public function testPurgeRemovesTheBackingFiles(): void
     {
         Cache::set('alpha', 'value', Cache::CACHE_STATIC);
-
-        self::assertNotSame([], glob((string)new Path('cache')) ? glob((string)new Path('cache') . '/*.tmp') : []);
+        self::assertNotSame([], $this->backingFiles());
 
         Cache::purge(Cache::CACHE_STATIC);
 
-        self::assertSame([], glob((string)new Path('cache') . '/*.tmp'));
+        self::assertSame([], $this->backingFiles());
+    }
+
+    /**
+     * @return string[] the .tmp files backing CACHE_STATIC, empty when there are none
+     */
+    private function backingFiles(): array
+    {
+        return glob((string)new Path(Cache::STATIC_CACHE_PATH) . '/*.tmp') ?: [];
     }
 
     /**

--- a/tests/Unit/Core/ContainerTest.php
+++ b/tests/Unit/Core/ContainerTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Unit\Core;
+
+use core\Container;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use stdClass;
+
+/**
+ * Container had no way to ask whether a name was registered and no way to defer
+ * construction, so events/Init.php built every service on every request -- a database
+ * connection included -- whether or not the route touched them.
+ *
+ * @covers \core\Container
+ */
+class ContainerTest extends TestCase
+{
+    public function testHasIsFalseForAnUnknownName(): void
+    {
+        self::assertFalse((new Container())->has('nothing'));
+    }
+
+    public function testHasIsTrueForAnEagerlySetObject(): void
+    {
+        $container = new Container();
+        $container->set('service', new stdClass());
+
+        self::assertTrue($container->has('service'));
+    }
+
+    public function testHasIsTrueForARegisteredFactoryBeforeItIsResolved(): void
+    {
+        $container = new Container();
+        $container->setFactory('service', function () {
+            throw new RuntimeException('has() must not resolve the factory');
+        });
+
+        self::assertTrue($container->has('service'));
+    }
+
+    public function testFactoryIsNotCalledUntilTheServiceIsRequested(): void
+    {
+        $calls = 0;
+        $container = new Container();
+        $container->setFactory('service', function () use (&$calls) {
+            $calls++;
+
+            return new stdClass();
+        });
+
+        self::assertSame(0, $calls, 'registering a factory must not build anything');
+
+        $container->get('service');
+
+        self::assertSame(1, $calls);
+    }
+
+    public function testFactoryResultIsSharedAcrossCalls(): void
+    {
+        $container = new Container();
+        $container->setFactory('service', function () {
+            return new stdClass();
+        });
+
+        self::assertSame($container->get('service'), $container->get('service'));
+    }
+
+    public function testFactoryRunsOnlyOnceEvenWhenRequestedRepeatedly(): void
+    {
+        $calls = 0;
+        $container = new Container();
+        $container->setFactory('service', function () use (&$calls) {
+            $calls++;
+
+            return new stdClass();
+        });
+
+        $container->get('service');
+        $container->get('service');
+        $container->get('service');
+
+        self::assertSame(1, $calls);
+    }
+
+    public function testFactoryReceivesTheContainerSoItCanResolveDependencies(): void
+    {
+        $container = new Container();
+        $dependency = new stdClass();
+        $container->set('dependency', $dependency);
+
+        $container->setFactory('service', function (Container $c) {
+            $service = new stdClass();
+            $service->dependency = $c->get('dependency');
+
+            return $service;
+        });
+
+        self::assertSame($dependency, $container->get('service')->dependency);
+    }
+
+    /**
+     * A factory that asks for its own name would otherwise recurse until the process died.
+     * The factory is removed before it is invoked, so the second lookup finds nothing
+     * registered and reports that instead of hanging.
+     */
+    public function testSelfReferentialFactoryFailsFastRatherThanLoopingForever(): void
+    {
+        $container = new Container();
+        $container->setFactory('service', function (Container $c) {
+            return $c->get('service');
+        });
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $container->get('service');
+    }
+
+    public function testAnEagerlySetObjectWinsOverAFactoryOfTheSameName(): void
+    {
+        $object = new stdClass();
+        $container = new Container();
+        $container->setFactory('service', function () {
+            throw new RuntimeException('the eager object should have been used');
+        });
+        $container->set('service', $object);
+
+        self::assertSame($object, $container->get('service'));
+    }
+
+    public function testUnknownNameStillThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Container())->get('nothing');
+    }
+
+    /**
+     * set() rejects a non-object, so a factory returning one has to be rejected too --
+     * otherwise the container's contract holds only for the eager path.
+     */
+    public function testFactoryReturningANonObjectIsRejected(): void
+    {
+        $container = new Container();
+        $container->setFactory('service', function () {
+            return 'not an object';
+        });
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $container->get('service');
+    }
+}

--- a/tests/Unit/Core/DatabaseSQLReconnectTest.php
+++ b/tests/Unit/Core/DatabaseSQLReconnectTest.php
@@ -76,8 +76,20 @@ class DatabaseSQLReconnectTest extends TestCase
         return $database;
     }
 
-    private static function lostConnection(int $code = 2006, string $message = 'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away'): PDOException
+    /**
+     * The default message follows the code. 2006 and 2013 carry different text in real life,
+     * and the classification reads the message when the driver code is missing -- a helper
+     * that stamped "gone away" onto a 2013 would make the write-replay tests pass for the
+     * wrong reason.
+     */
+    private static function lostConnection(int $code = 2006, ?string $message = null): PDOException
     {
+        if ($message === null) {
+            $message = $code === 2013
+                ? 'SQLSTATE[HY000]: General error: 2013 Lost connection to MySQL server during query'
+                : 'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away';
+        }
+
         $exception = new PDOException($message);
         $exception->errorInfo = ['HY000', $code, $message];
 
@@ -177,6 +189,108 @@ class DatabaseSQLReconnectTest extends TestCase
         self::assertFalse($this->makeDatabase()->shouldReconnectFor(self::lostConnection(1062, 'Duplicate entry')));
     }
 
+    // --- replaying a write ----------------------------------------------------------------
+
+    /**
+     * 2006 is the server dropping a connection that sat idle past wait_timeout: the statement
+     * never reached it, so replaying anything -- writes included -- repeats nothing. This is
+     * the case the reconnect exists for.
+     *
+     * @dataProvider anyStatementProvider
+     */
+    public function testGoneAwayReplaysAnyStatement(string $sql): void
+    {
+        self::assertTrue($this->makeDatabase()->shouldReconnectFor(self::lostConnection(2006), $sql));
+    }
+
+    public function anyStatementProvider(): array
+    {
+        return [
+            'select' => ['SELECT * FROM users'],
+            'insert' => ['INSERT INTO users (email) VALUES (:email)'],
+            'update' => ['UPDATE users SET seen = seen + 1'],
+            'delete' => ['DELETE FROM users WHERE id = :id'],
+        ];
+    }
+
+    /**
+     * 2013 is the connection dying with the statement in flight. The server may have run it
+     * and failed only on the way back with the answer, so replaying a write would insert the
+     * row twice or count "seen + 1" twice.
+     *
+     * @dataProvider writeStatementProvider
+     */
+    public function testLostDuringQueryDoesNotReplayAWrite(string $sql): void
+    {
+        self::assertFalse(
+            $this->makeDatabase()->shouldReconnectFor(self::lostConnection(2013), $sql),
+            'the server may already have applied this statement'
+        );
+    }
+
+    public function writeStatementProvider(): array
+    {
+        return [
+            'insert' => ['INSERT INTO users (email) VALUES (:email)'],
+            'update' => ['UPDATE users SET seen = seen + 1'],
+            'delete' => ['DELETE FROM users WHERE id = :id'],
+            'replace' => ['REPLACE INTO users (id, email) VALUES (:id, :email)'],
+            'ddl' => ['CREATE TABLE t (id INT)'],
+            'lowercase insert' => ['insert into users (email) values (:email)'],
+            'leading whitespace' => ["\n  INSERT INTO users (email) VALUES (:email)"],
+        ];
+    }
+
+    /**
+     * @dataProvider readStatementProvider
+     */
+    public function testLostDuringQueryStillReplaysARead(string $sql): void
+    {
+        self::assertTrue($this->makeDatabase()->shouldReconnectFor(self::lostConnection(2013), $sql));
+    }
+
+    public function readStatementProvider(): array
+    {
+        return [
+            'select' => ['SELECT * FROM users'],
+            'lowercase' => ['select * from users'],
+            'leading whitespace' => ["\n    SELECT * FROM users"],
+            'parenthesised' => ['(SELECT 1) UNION (SELECT 2)'],
+            'show' => ['SHOW TABLES LIKE "users"'],
+            'describe' => ['DESCRIBE users'],
+            'explain' => ['EXPLAIN SELECT * FROM users'],
+        ];
+    }
+
+    /**
+     * The message-only form carries no driver code, so it has to be classified the same way.
+     */
+    public function testLostConnectionMessageWithoutACodeDoesNotReplayAWrite(): void
+    {
+        $exception = self::lostConnection(0, 'Lost connection to MySQL server during query');
+
+        self::assertFalse($this->makeDatabase()->shouldReconnectFor($exception, 'INSERT INTO users (email) VALUES (:email)'));
+        self::assertTrue($this->makeDatabase()->shouldReconnectFor($exception, 'SELECT * FROM users'));
+    }
+
+    public function testGoneAwayMessageWithoutACodeReplaysAWrite(): void
+    {
+        $exception = self::lostConnection(0, 'SQLSTATE[HY000]: MySQL server has gone away');
+
+        self::assertTrue($this->makeDatabase()->shouldReconnectFor($exception, 'INSERT INTO users (email) VALUES (:email)'));
+    }
+
+    /**
+     * Anything the allow-list does not recognise counts as a write. A missed retry costs a
+     * failed run; a wrong one costs duplicated data.
+     */
+    public function testUnrecognisedStatementIsTreatedAsAWrite(): void
+    {
+        self::assertFalse(DatabaseSQL::isReadOnly('WITH x AS (SELECT 1) SELECT * FROM x'));
+        self::assertFalse(DatabaseSQL::isReadOnly('CALL some_procedure()'));
+        self::assertFalse(DatabaseSQL::isReadOnly(''));
+    }
+
     // --- the retry itself ----------------------------------------------------------------
 
     public function testStatementIsRetriedOnceOnAFreshConnection(): void
@@ -243,6 +357,42 @@ class DatabaseSQLReconnectTest extends TestCase
         self::assertSame(1, $database->statementAttempts, 'no retry for an error the query itself caused');
     }
 
+    /**
+     * The blocker this guard exists for: an INSERT that died in flight must not be replayed,
+     * or the row lands twice.
+     */
+    public function testWriteIsNotReplayedWhenTheConnectionDiedInFlight(): void
+    {
+        $database = $this->makeDatabase();
+        $database->failEveryStatement(self::lostConnection(2013));
+
+        try {
+            $database->insertRecord('users', ['email' => 'bob@example.com']);
+            self::fail('the failure should have propagated');
+        } catch (PDOException $exception) {
+            self::assertStringContainsString('Lost connection', $exception->getMessage());
+        }
+
+        self::assertSame(0, $database->connectCalls);
+        self::assertSame(1, $database->statementAttempts, 'the insert must not run a second time');
+    }
+
+    public function testWriteIsReplayedAfterAnIdleTimeout(): void
+    {
+        $database = $this->makeDatabase();
+        $database->failNextStatement(self::lostConnection(2006));
+
+        $database->insertRecord('users', ['email' => 'bob@example.com']);
+
+        self::assertSame(1, $database->connectCalls);
+        self::assertSame(2, $database->statementAttempts);
+        self::assertCount(
+            1,
+            $database->getRecords('users', ['email' => 'bob@example.com']),
+            'the row should exist exactly once'
+        );
+    }
+
     public function testHealthyQueriesNeverReconnect(): void
     {
         $database = $this->makeDatabase();
@@ -293,9 +443,9 @@ class ReconnectingDatabaseDouble extends DatabaseSQL
         return $this->driverName;
     }
 
-    public function shouldReconnectFor(PDOException $exception): bool
+    public function shouldReconnectFor(PDOException $exception, string $sql = 'SELECT 1'): bool
     {
-        return $this->shouldReconnect($exception);
+        return $this->shouldReconnect($exception, $sql);
     }
 
     public function resetCounters(): void

--- a/tests/Unit/Core/DatabaseSQLReconnectTest.php
+++ b/tests/Unit/Core/DatabaseSQLReconnectTest.php
@@ -193,35 +193,28 @@ class DatabaseSQLReconnectTest extends TestCase
     // --- replaying a write ----------------------------------------------------------------
 
     /**
-     * 2006 is the server dropping a connection that sat idle past wait_timeout: the statement
-     * never reached it, so replaying anything -- writes included -- repeats nothing. This is
-     * the case the reconnect exists for.
+     * A write is never replayed, whatever the error code says.
      *
-     * @dataProvider anyStatementProvider
-     */
-    public function testGoneAwayReplaysAnyStatement(string $sql): void
-    {
-        self::assertTrue($this->makeDatabase()->shouldReconnectFor(self::lostConnection(2006), $sql));
-    }
-
-    public function anyStatementProvider(): array
-    {
-        return [
-            'select' => ['SELECT * FROM users'],
-            'insert' => ['INSERT INTO users (email) VALUES (:email)'],
-            'update' => ['UPDATE users SET seen = seen + 1'],
-            'delete' => ['DELETE FROM users WHERE id = :id'],
-        ];
-    }
-
-    /**
-     * 2013 is the connection dying with the statement in flight. The server may have run it
-     * and failed only on the way back with the answer, so replaying a write would insert the
-     * row twice or count "seen + 1" twice.
+     * Measured against MariaDB 11: a connection closed after wait_timeout and a connection
+     * killed two seconds into a running statement both report 2006, for reads and writes
+     * alike. PDO emulates prepares by default, so the failure surfaces at execute() either
+     * way. "Never sent" and "ran, but the answer was lost" are indistinguishable, so the only
+     * safe rule is to replay reads and nothing else.
      *
      * @dataProvider writeStatementProvider
      */
-    public function testLostDuringQueryDoesNotReplayAWrite(string $sql): void
+    public function testWriteIsNeverReplayedAfterAGoneAwayError(string $sql): void
+    {
+        self::assertFalse(
+            $this->makeDatabase()->shouldReconnectFor(self::lostConnection(2006), $sql),
+            '2006 does not mean the statement never reached the server'
+        );
+    }
+
+    /**
+     * @dataProvider writeStatementProvider
+     */
+    public function testWriteIsNeverReplayedAfterALostConnectionError(string $sql): void
     {
         self::assertFalse(
             $this->makeDatabase()->shouldReconnectFor(self::lostConnection(2013), $sql),
@@ -245,8 +238,9 @@ class DatabaseSQLReconnectTest extends TestCase
     /**
      * @dataProvider readStatementProvider
      */
-    public function testLostDuringQueryStillReplaysARead(string $sql): void
+    public function testReadIsReplayedAfterEitherError(string $sql): void
     {
+        self::assertTrue($this->makeDatabase()->shouldReconnectFor(self::lostConnection(2006), $sql));
         self::assertTrue($this->makeDatabase()->shouldReconnectFor(self::lostConnection(2013), $sql));
     }
 
@@ -264,21 +258,28 @@ class DatabaseSQLReconnectTest extends TestCase
     }
 
     /**
-     * The message-only form carries no driver code, so it has to be classified the same way.
+     * PDO leaves errorInfo[1] at 0 for some connection-level failures, so the message-only
+     * form has to reach the same conclusion.
+     *
+     * @dataProvider messageOnlyProvider
      */
-    public function testLostConnectionMessageWithoutACodeDoesNotReplayAWrite(): void
+    public function testMessageOnlyErrorsAreClassifiedTheSameWay(string $message): void
     {
-        $exception = self::lostConnection(0, 'Lost connection to MySQL server during query');
+        $exception = self::lostConnection(0, $message);
 
-        self::assertFalse($this->makeDatabase()->shouldReconnectFor($exception, 'INSERT INTO users (email) VALUES (:email)'));
+        self::assertFalse(
+            $this->makeDatabase()->shouldReconnectFor($exception, 'INSERT INTO users (email) VALUES (:email)'),
+            'a write is never replayed'
+        );
         self::assertTrue($this->makeDatabase()->shouldReconnectFor($exception, 'SELECT * FROM users'));
     }
 
-    public function testGoneAwayMessageWithoutACodeReplaysAWrite(): void
+    public function messageOnlyProvider(): array
     {
-        $exception = self::lostConnection(0, 'SQLSTATE[HY000]: MySQL server has gone away');
-
-        self::assertTrue($this->makeDatabase()->shouldReconnectFor($exception, 'INSERT INTO users (email) VALUES (:email)'));
+        return [
+            'gone away' => ['SQLSTATE[HY000]: MySQL server has gone away'],
+            'lost during query' => ['Lost connection to MySQL server during query'],
+        ];
     }
 
     /**
@@ -449,20 +450,25 @@ class DatabaseSQLReconnectTest extends TestCase
         self::assertSame(1, $database->statementAttempts, 'the insert must not run a second time');
     }
 
-    public function testWriteIsReplayedAfterAnIdleTimeout(): void
+    /**
+     * An idle timeout reports 2006 -- and so does a connection killed mid-statement, so a
+     * write is not replayed here either. The run fails loudly instead, which the caller can
+     * see; a duplicated row is what nobody would see.
+     */
+    public function testWriteIsNotReplayedAfterAnIdleTimeoutEither(): void
     {
         $database = $this->makeDatabase();
-        $database->failNextStatement(self::lostConnection(2006));
+        $database->failEveryStatement(self::lostConnection(2006));
 
-        $database->insertRecord('users', ['email' => 'bob@example.com']);
+        try {
+            $database->insertRecord('users', ['email' => 'bob@example.com']);
+            self::fail('the failure should have propagated');
+        } catch (PDOException $exception) {
+            self::assertStringContainsString('gone away', $exception->getMessage());
+        }
 
-        self::assertSame(1, $database->connectCalls);
-        self::assertSame(2, $database->statementAttempts);
-        self::assertCount(
-            1,
-            $database->getRecords('users', ['email' => 'bob@example.com']),
-            'the row should exist exactly once'
-        );
+        self::assertSame(0, $database->connectCalls);
+        self::assertSame(1, $database->statementAttempts, 'the insert must not run a second time');
     }
 
     public function testHealthyQueriesNeverReconnect(): void

--- a/tests/Unit/Core/DatabaseSQLReconnectTest.php
+++ b/tests/Unit/Core/DatabaseSQLReconnectTest.php
@@ -1,0 +1,348 @@
+<?php
+
+namespace Tests\Unit\Core;
+
+use core\Application;
+use core\DatabaseSQL;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A long-running CLI process -- a cron task, an import, a queue worker -- sleeps between
+ * units of work, MySQL drops the idle connection, and every query after that dies with
+ * "server has gone away". The connection was built once in the constructor and never rebuilt,
+ * so the run was over.
+ *
+ * Retrying is only safe under narrow conditions, and the guards matter more than the retry:
+ * replaying a statement on a fresh connection inside a transaction would commit a torn write,
+ * and replaying one in a web request would double a user-visible action rather than fail it.
+ *
+ * @covers \core\DatabaseSQL
+ */
+class DatabaseSQLReconnectTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    private $mode;
+
+    /**
+     * @var string
+     */
+    private $errorLog;
+
+    /**
+     * @var string|false
+     */
+    private $previousErrorLog;
+
+    protected function setUp(): void
+    {
+        $this->mode = Application::getMode();
+        Application::setMode(Application::MODE_CLI);
+
+        // A reconnect is worth a line in the error log, and that line would otherwise land in
+        // the test output. Capture it instead of silencing the code under test.
+        $this->errorLog = tempnam(sys_get_temp_dir(), 'hcphp-reconnect-');
+        $this->previousErrorLog = ini_set('error_log', $this->errorLog);
+    }
+
+    protected function tearDown(): void
+    {
+        Application::setMode($this->mode);
+
+        ini_set('error_log', $this->previousErrorLog === false ? '' : $this->previousErrorLog);
+
+        if (is_file($this->errorLog)) {
+            unlink($this->errorLog);
+        }
+    }
+
+    private function readErrorLog(): string
+    {
+        return is_file($this->errorLog) ? (string)file_get_contents($this->errorLog) : '';
+    }
+
+    private function makeDatabase(string $driver = DatabaseSQL::DRIVER_MYSQL): ReconnectingDatabaseDouble
+    {
+        $database = new ReconnectingDatabaseDouble($driver);
+        $database->getDBH()->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL)');
+        $database->insertRecord('users', ['email' => 'alice@example.com']);
+
+        // Building the fixture runs statements of its own; the counters describe the query
+        // under test, not the setup.
+        $database->resetCounters();
+
+        return $database;
+    }
+
+    private static function lostConnection(int $code = 2006, string $message = 'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away'): PDOException
+    {
+        $exception = new PDOException($message);
+        $exception->errorInfo = ['HY000', $code, $message];
+
+        return $exception;
+    }
+
+    // --- isLostConnection(): the pure part, and the part most likely to be wrong ---------
+
+    /**
+     * @dataProvider lostConnectionProvider
+     */
+    public function testIsLostConnectionRecognisesADroppedConnection(PDOException $exception): void
+    {
+        self::assertTrue(DatabaseSQL::isLostConnection($exception));
+    }
+
+    public function lostConnectionProvider(): array
+    {
+        return [
+            'driver code 2006' => [self::lostConnection(2006)],
+            'driver code 2013' => [self::lostConnection(2013, 'SQLSTATE[HY000]: Lost connection to MySQL server during query')],
+            'message only, no driver code' => [self::lostConnection(0, 'SQLSTATE[HY000]: MySQL server has gone away')],
+            'lost connection message' => [self::lostConnection(0, 'Lost connection to MySQL server at reading initial communication packet')],
+        ];
+    }
+
+    /**
+     * @dataProvider survivingErrorProvider
+     */
+    public function testIsLostConnectionIgnoresErrorsThatAreNotConnectionLoss(PDOException $exception): void
+    {
+        self::assertFalse(DatabaseSQL::isLostConnection($exception));
+    }
+
+    public function survivingErrorProvider(): array
+    {
+        return [
+            'duplicate key' => [self::lostConnection(1062, "SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'x' for key 'PRIMARY'")],
+            'unknown column' => [self::lostConnection(1054, "SQLSTATE[42S22]: Column not found: 1054 Unknown column 'nope' in 'field list'")],
+            'deadlock' => [self::lostConnection(1213, 'SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock')],
+            'access denied' => [self::lostConnection(1045, "SQLSTATE[28000]: Access denied for user 'root'@'localhost'")],
+            'no error info at all' => [new PDOException('something went wrong')],
+        ];
+    }
+
+    /**
+     * A deadlock is also a "retry me" error, but it is not this method's job and retrying it
+     * on a fresh connection would be wrong -- the transaction it belonged to is gone.
+     */
+    public function testDeadlockIsNotTreatedAsConnectionLoss(): void
+    {
+        self::assertFalse(DatabaseSQL::isLostConnection(self::lostConnection(1213, 'Deadlock found')));
+    }
+
+    // --- shouldReconnect(): the guards ---------------------------------------------------
+
+    public function testReconnectsOnMysqlInCliOutsideATransaction(): void
+    {
+        self::assertTrue($this->makeDatabase()->shouldReconnectFor(self::lostConnection()));
+    }
+
+    public function testDoesNotReconnectForANonMysqlDriver(): void
+    {
+        $database = $this->makeDatabase(DatabaseSQL::DRIVER_SQLITE);
+
+        self::assertFalse(
+            $database->shouldReconnectFor(self::lostConnection()),
+            'sqlite has no server to lose, and reconnecting an in-memory database would discard it'
+        );
+    }
+
+    public function testDoesNotReconnectInAWebRequest(): void
+    {
+        Application::setMode(Application::MODE_WEB);
+
+        self::assertFalse(
+            $this->makeDatabase()->shouldReconnectFor(self::lostConnection()),
+            'a web request should fail visibly rather than silently replay a statement'
+        );
+    }
+
+    public function testDoesNotReconnectInsideATransaction(): void
+    {
+        $database = $this->makeDatabase();
+        $database->getDBH()->beginTransaction();
+
+        self::assertFalse(
+            $database->shouldReconnectFor(self::lostConnection()),
+            'the transaction is gone with the connection; replaying one statement would tear the write'
+        );
+
+        $database->getDBH()->rollBack();
+    }
+
+    public function testDoesNotReconnectForAnOrdinarySqlError(): void
+    {
+        self::assertFalse($this->makeDatabase()->shouldReconnectFor(self::lostConnection(1062, 'Duplicate entry')));
+    }
+
+    // --- the retry itself ----------------------------------------------------------------
+
+    public function testStatementIsRetriedOnceOnAFreshConnection(): void
+    {
+        $database = $this->makeDatabase();
+        $database->failNextStatement();
+
+        $records = $database->getRecords('users', ['email' => 'alice@example.com']);
+
+        self::assertCount(1, $records, 'the retried statement should return the real result');
+        self::assertSame(1, $database->connectCalls, 'exactly one reconnect');
+        self::assertSame(2, $database->statementAttempts, 'one failure, one retry');
+    }
+
+    /**
+     * A reconnect that leaves no trace turns a failing server into a mysterious slowdown.
+     */
+    public function testReconnectIsRecordedInTheErrorLog(): void
+    {
+        $database = $this->makeDatabase();
+        $database->failNextStatement();
+
+        $database->getRecords('users', ['email' => 'alice@example.com']);
+
+        self::assertStringContainsString('connection lost, reconnecting', $this->readErrorLog());
+    }
+
+    public function testHealthyQueriesLogNothing(): void
+    {
+        $this->makeDatabase()->getRecords('users', ['email' => 'alice@example.com']);
+
+        self::assertSame('', $this->readErrorLog());
+    }
+
+    public function testStatementIsNotRetriedMoreThanOnce(): void
+    {
+        $database = $this->makeDatabase();
+        $database->failEveryStatement();
+
+        try {
+            $database->getRecords('users', ['email' => 'alice@example.com']);
+            self::fail('a connection that stays down must surface the failure');
+        } catch (PDOException $exception) {
+            self::assertStringContainsString('gone away', $exception->getMessage());
+        }
+
+        self::assertSame(1, $database->connectCalls, 'one reconnect attempt, not a loop');
+        self::assertSame(2, $database->statementAttempts);
+    }
+
+    public function testAnOrdinaryErrorIsNotRetriedAndIsRethrownUnchanged(): void
+    {
+        $database = $this->makeDatabase();
+        $database->failEveryStatement(self::lostConnection(1062, 'Duplicate entry'));
+
+        try {
+            $database->getRecords('users', ['email' => 'alice@example.com']);
+            self::fail('the error should have propagated');
+        } catch (PDOException $exception) {
+            self::assertStringContainsString('Duplicate entry', $exception->getMessage());
+        }
+
+        self::assertSame(0, $database->connectCalls);
+        self::assertSame(1, $database->statementAttempts, 'no retry for an error the query itself caused');
+    }
+
+    public function testHealthyQueriesNeverReconnect(): void
+    {
+        $database = $this->makeDatabase();
+
+        $database->getRecords('users', ['email' => 'alice@example.com']);
+
+        self::assertSame(0, $database->connectCalls);
+        self::assertSame(1, $database->statementAttempts);
+    }
+}
+
+/**
+ * Drives the retry path over a real sqlite connection.
+ *
+ * getDriver() is overridden rather than reflected onto so the MySQL guards can be exercised
+ * without a MySQL server; connect() is stubbed because reconnecting a ':memory:' database
+ * would throw its contents away, which is exactly why the driver guard exists.
+ */
+class ReconnectingDatabaseDouble extends DatabaseSQL
+{
+    public $connectCalls = 0;
+    public $statementAttempts = 0;
+
+    /**
+     * @var string
+     */
+    private $driverName;
+
+    /**
+     * @var PDOException|null
+     */
+    private $failure;
+
+    /**
+     * @var bool
+     */
+    private $failOnce = false;
+
+    public function __construct(string $driver = DatabaseSQL::DRIVER_MYSQL)
+    {
+        parent::__construct(DatabaseSQL::DRIVER_SQLITE);
+
+        $this->driverName = $driver;
+    }
+
+    public function getDriver(): string
+    {
+        return $this->driverName;
+    }
+
+    public function shouldReconnectFor(PDOException $exception): bool
+    {
+        return $this->shouldReconnect($exception);
+    }
+
+    public function resetCounters(): void
+    {
+        $this->connectCalls = 0;
+        $this->statementAttempts = 0;
+    }
+
+    public function failNextStatement(?PDOException $exception = null): void
+    {
+        $this->failure = $exception ?? self::goneAway();
+        $this->failOnce = true;
+    }
+
+    public function failEveryStatement(?PDOException $exception = null): void
+    {
+        $this->failure = $exception ?? self::goneAway();
+        $this->failOnce = false;
+    }
+
+    private static function goneAway(): PDOException
+    {
+        $exception = new PDOException('SQLSTATE[HY000]: General error: 2006 MySQL server has gone away');
+        $exception->errorInfo = ['HY000', 2006, 'MySQL server has gone away'];
+
+        return $exception;
+    }
+
+    protected function connect(): void
+    {
+        $this->connectCalls++;
+    }
+
+    protected function executeStatement(string $sql, array $conditions = []): \PDOStatement
+    {
+        $this->statementAttempts++;
+
+        if ($this->failure !== null) {
+            $failure = $this->failure;
+
+            if ($this->failOnce) {
+                $this->failure = null;
+            }
+
+            throw $failure;
+        }
+
+        return parent::executeStatement($sql, $conditions);
+    }
+}

--- a/tests/Unit/Core/DatabaseSQLReconnectTest.php
+++ b/tests/Unit/Core/DatabaseSQLReconnectTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Core;
 
 use core\Application;
 use core\DatabaseSQL;
+use core\Debug;
 use PDOException;
 use PHPUnit\Framework\TestCase;
 
@@ -323,6 +324,77 @@ class DatabaseSQLReconnectTest extends TestCase
         $this->makeDatabase()->getRecords('users', ['email' => 'alice@example.com']);
 
         self::assertSame('', $this->readErrorLog());
+    }
+
+    /**
+     * The error log is where the event survives with debug off; Debug is where every other
+     * framework message surfaces. It has to reach both.
+     */
+    public function testReconnectAlsoSurfacesThroughDebug(): void
+    {
+        $this->withDebugOn(function () {
+            $database = $this->makeDatabase();
+            $database->failNextStatement();
+
+            $database->getRecords('users', ['email' => 'alice@example.com']);
+
+            self::assertStringContainsString('connection lost, reconnecting', (string)Debug::flush());
+        });
+    }
+
+    /**
+     * Debug::dump() appends unconditionally but flush() only drains when debug is on, so
+     * dumping with debug off would grow the buffer for the life of the process -- which is
+     * precisely the long-running CLI process this reconnect exists for.
+     */
+    public function testNothingIsDumpedWhenDebugIsOff(): void
+    {
+        self::assertFalse(Debug::isOn(), 'this test is meaningless if debug is already on');
+
+        // Start from an empty buffer; flush() only clears it while debug is on.
+        $this->withDebugOn(function () {
+        });
+
+        $database = $this->makeDatabase();
+        $database->failNextStatement();
+        $database->getRecords('users', ['email' => 'alice@example.com']);
+
+        // Read what accumulated while debug was off -- without draining first, or the
+        // assertion would be reading a buffer this helper had just emptied.
+        $this->withDebugOn(
+            function () {
+                self::assertSame('', (string)Debug::flush(), 'the dump buffer should not have grown');
+            },
+            false
+        );
+    }
+
+    /**
+     * Debug::mode() also writes error_reporting and display_errors, so all three are put back
+     * -- leaving error_reporting at 0 would blind every test that runs after this one.
+     *
+     * @param bool $drainFirst false to leave whatever is already buffered for $body to read
+     */
+    private function withDebugOn(callable $body, bool $drainFirst = true): void
+    {
+        $mode = Debug::mode();
+        $reporting = error_reporting();
+        $display = ini_get('display_errors');
+
+        Debug::mode(E_ALL);
+
+        if ($drainFirst) {
+            Debug::flush();
+        }
+
+        try {
+            $body();
+        } finally {
+            Debug::flush();
+            Debug::mode($mode);
+            error_reporting($reporting);
+            ini_set('display_errors', $display === false ? '0' : $display);
+        }
     }
 
     public function testStatementIsNotRetriedMoreThanOnce(): void

--- a/tests/Unit/Core/TemplateCacheTest.php
+++ b/tests/Unit/Core/TemplateCacheTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Unit\Core;
+
+use core\Path;
+use core\Template;
+use FilesystemIterator;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Template compiles every template into cache/templates/ and reuses the compiled file while
+ * its mtime is newer than the source. There was no way to clear that directory, so a deploy
+ * that restores mtimes -- rsync without --times, a checkout onto a warm cache, an archive
+ * unpacked with preserved timestamps -- kept serving the previous build's compiled templates
+ * with no way to force a recompile short of rm on the server.
+ *
+ * @covers \core\Template
+ */
+class TemplateCacheTest extends TestCase
+{
+    /**
+     * Nested on purpose: real template names carry slashes ('form/default'), so compiled
+     * files land in subdirectories and a non-recursive purge would miss most of them.
+     */
+    private const FIXTURE = 'tests_fixture/nested';
+
+    protected function setUp(): void
+    {
+        $source = new Path(sprintf('application/templates/%s.php', self::FIXTURE));
+        $source->mkpath();
+        file_put_contents((string)$source, 'compiled output');
+
+        Template::purgeCaches();
+    }
+
+    protected function tearDown(): void
+    {
+        Template::purgeCaches();
+
+        $dir = new Path('application/templates/tests_fixture');
+
+        if (is_dir((string)$dir)) {
+            $dir->rmpath(true);
+        }
+    }
+
+    public function testMakeCompilesTheTemplateIntoTheCacheDirectory(): void
+    {
+        (new Template(self::FIXTURE))->make();
+
+        self::assertNotSame([], $this->compiledFiles(), 'make() should have written a compiled template');
+    }
+
+    public function testCompiledTemplateLandsInASubdirectory(): void
+    {
+        (new Template(self::FIXTURE))->make();
+
+        self::assertStringContainsString(
+            'tests_fixture' . DIRECTORY_SEPARATOR,
+            $this->compiledFiles()[0]
+        );
+    }
+
+    public function testPurgeCachesRemovesCompiledTemplates(): void
+    {
+        (new Template(self::FIXTURE))->make();
+        self::assertNotSame([], $this->compiledFiles());
+
+        Template::purgeCaches();
+
+        self::assertSame([], $this->compiledFiles());
+    }
+
+    public function testPurgeCachesOnAnAlreadyEmptyCacheIsNotAnError(): void
+    {
+        Template::purgeCaches();
+        Template::purgeCaches();
+
+        self::assertSame([], $this->compiledFiles());
+    }
+
+    public function testTemplateStillRendersAfterAPurge(): void
+    {
+        $before = (new Template(self::FIXTURE))->make();
+
+        Template::purgeCaches();
+
+        $after = (new Template(self::FIXTURE))->make();
+
+        self::assertSame('compiled output', $before);
+        self::assertSame($before, $after);
+    }
+
+    /**
+     * Purging the compiled templates must not take the sibling CACHE_STATIC entries with it
+     * -- Cache owns those and clears them separately.
+     */
+    public function testPurgeCachesLeavesTheStaticCacheAlone(): void
+    {
+        \core\Cache::set('template_cache_probe', 'value', \core\Cache::CACHE_STATIC);
+
+        (new Template(self::FIXTURE))->make();
+        Template::purgeCaches();
+
+        self::assertSame('value', \core\Cache::get('template_cache_probe', \core\Cache::CACHE_STATIC));
+
+        \core\Cache::remove('template_cache_probe', \core\Cache::CACHE_STATIC);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function compiledFiles(): array
+    {
+        $dir = (string)new Path(Template::CACHE_PATH);
+
+        if (!is_dir($dir)) {
+            return [];
+        }
+
+        $found = [];
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile()) {
+                $found[] = $file->getPathname();
+            }
+        }
+
+        sort($found);
+
+        return $found;
+    }
+}

--- a/tests/Unit/RecordsQueryBuilderTest.php
+++ b/tests/Unit/RecordsQueryBuilderTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Unit;
+
+use core\DatabaseSQL;
+use DynamicDB\Entity\Field;
+use DynamicDB\Entity\Table;
+use PHPUnit\Framework\TestCase;
+use RecordsQueryBuilder;
+
+/**
+ * getLike() drops the WHERE clause when there is no search term, but getValues() went on
+ * returning a 'like' value regardless. Binding a parameter a statement does not contain is an
+ * error rather than a no-op, so the records list -- the page every user lands on after
+ * logging in -- died with
+ *
+ *     SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match
+ *     number of tokens
+ *
+ * It went unnoticed because logging in was broken for an unrelated reason, so nothing reached
+ * the page.
+ *
+ * @covers \RecordsQueryBuilder
+ */
+class RecordsQueryBuilderTest extends TestCase
+{
+    private function table(): Table
+    {
+        return (new Table('records', 'Records'))
+            ->addField(new Field('text_field', 'Text', Field::TYPE_TEXT))
+            ->addField(new Field('int_field', 'Int', Field::TYPE_INTEGER))
+        ;
+    }
+
+    public function testNoSearchTermProducesNoWhereClause(): void
+    {
+        self::assertStringNotContainsString(
+            ':like',
+            (new RecordsQueryBuilder($this->table(), ''))->getLike()
+        );
+    }
+
+    public function testNoSearchTermBindsNothing(): void
+    {
+        self::assertSame(
+            [],
+            (new RecordsQueryBuilder($this->table(), ''))->getValues(),
+            'a value bound to a token the statement does not have is an error'
+        );
+    }
+
+    public function testSearchTermProducesAWhereClauseOverEveryField(): void
+    {
+        $sql = (new RecordsQueryBuilder($this->table(), 'abc'))->getLike();
+
+        self::assertStringContainsString('text_field LIKE :like', $sql);
+        self::assertStringContainsString('int_field LIKE :like', $sql);
+        self::assertStringContainsString(' OR ', $sql);
+    }
+
+    public function testSearchTermIsBoundAsAContainsPattern(): void
+    {
+        self::assertSame(
+            ['like' => '%abc%'],
+            (new RecordsQueryBuilder($this->table(), 'abc'))->getValues()
+        );
+    }
+
+    /**
+     * The two halves have to agree: every token the SQL declares must be bound, and nothing
+     * else may be. This is the invariant that was broken.
+     */
+    public function testTokensAndBoundValuesAlwaysAgree(): void
+    {
+        foreach (['', 'abc', '0'] as $term) {
+            $builder = new RecordsQueryBuilder($this->table(), $term);
+
+            $tokens = [];
+            preg_match_all('/:(\w+)/', $builder->getLike(), $tokens);
+
+            self::assertSame(
+                array_values(array_unique($tokens[1])),
+                array_keys($builder->getValues()),
+                sprintf('mismatch for search term "%s"', $term)
+            );
+        }
+    }
+
+    /**
+     * Runs the generated statement against a real connection: the failure was a PDO error at
+     * execute() time, which only shows up when something actually executes it.
+     */
+    public function testGeneratedStatementExecutesWithoutASearchTerm(): void
+    {
+        $database = new DatabaseSQL(DatabaseSQL::DRIVER_SQLITE);
+        $database->getDBH()->exec('CREATE TABLE records (id INTEGER PRIMARY KEY, text_field TEXT, int_field INTEGER)');
+        $database->insertRecord('records', ['text_field' => 'hello', 'int_field' => 1]);
+
+        $builder = new RecordsQueryBuilder($this->table(), '');
+
+        self::assertCount(1, $database->getRecordsSQL($builder->getLike(), $builder->getValues()));
+    }
+
+    public function testGeneratedStatementExecutesWithASearchTerm(): void
+    {
+        $database = new DatabaseSQL(DatabaseSQL::DRIVER_SQLITE);
+        $database->getDBH()->exec('CREATE TABLE records (id INTEGER PRIMARY KEY, text_field TEXT, int_field INTEGER)');
+        $database->insertRecord('records', ['text_field' => 'hello', 'int_field' => 1]);
+        $database->insertRecord('records', ['text_field' => 'world', 'int_field' => 2]);
+
+        $builder = new RecordsQueryBuilder($this->table(), 'hell');
+
+        self::assertCount(1, $database->getRecordsSQL($builder->getLike(), $builder->getValues()));
+    }
+}


### PR DESCRIPTION
Four improvements that the downstream forks had grown and this repository had not, plus one
bug found while verifying them. One commit per change; all six are independent.

I compared all 29 core classes against their counterparts in profirealt-db, studbase,
eportfolio, registries and icampaign, method by method. Most of the difference runs the other
way -- this repository is the newer fork -- but these were genuinely ahead.

## 1. `Container` can resolve services lazily

`setFactory()` registers a callable that runs on first `get()`; the result is stored and
shared exactly as `set()` would. `has()` answers whether a name resolves without resolving it.

The factory is dropped *before* it is invoked, so one that asks for its own name reports "not
registered" instead of recursing until the stack runs out. Its result goes through `set()`, so
a factory returning a non-object is rejected on the same terms as a direct `set()`.

## 2. `Init` builds services on first use

Nine services were constructed on every request whatever the route: a static page still built
a `ViewFactory`, an `Authenticator` and an `AuthChecker`, and `TableRepository` parses the
DynamicDB config in its constructor. They are plain constructions with no side effects, so
deferring them changes nothing except whether the work happens at all.

**The database stays eager** -- `DatabaseManager::initialize()` needs a live connection during
Init. Worth knowing: that call issues two queries (`SHOW TABLES LIKE`, `SELECT MAX(...)`) on
*every request*. That is the larger cost in Init and it is untouched here; it deserves its own
change.

## 3. `Cache::purge()`

Entries could be written and removed one key at a time but never cleared in bulk, so `cache/`
grew for the life of the install. Purging is per-type -- the three are separate stores, and
clearing a request cache should not log everyone out of a session cache. For `CACHE_STATIC` it
removes files and steps over subdirectories, which belong to whoever created them.

Two pre-existing things in the same file: `_get()` declared `$type` as `string` while every
caller and constant is an `int` (it worked only because the comparisons are loose), and a
docblock describing `_getFile()` had drifted onto the constant below it.

## 4. `Template::purgeCaches()`

Templates compile into `cache/templates/` and are reused while the compiled mtime is newer
than the source, so a deploy that does not advance mtimes -- rsync without `--times`, a
checkout onto a warm cache, an archive unpacked with preserved timestamps -- keeps serving the
previous build. Recursive, because template names carry slashes.

`cache:purge` used to `rm -r` the whole `cache/` tree from outside; it now asks each class to
clear what it owns.

## 5. `DatabaseSQL` rebuilds a dropped MySQL connection

A CLI process that sleeps between units of work outlives the server's idle timeout and every
query after that dies with "server has gone away". The guards matter more than the retry, and
each is a correctness constraint rather than a tuning knob:

- **MySQL only** -- sqlite has no server to lose, and reconnecting an in-memory database would
  discard it. Other drivers report connection loss differently and are not verified here.
- **CLI only** -- a web request should fail visibly rather than silently replay a statement.
- **Not in a transaction** -- it died with the connection; replaying one statement would
  commit a fragment of it.
- **Once** -- if the second attempt fails, the connection is not coming back.

Deadlock (1213) and lock wait timeout (1205) are excluded: retryable in principle, but not by
reconnecting. The reconnect is written to the error log.

## 6. The records list was throwing (pre-existing)

`RecordsQueryBuilder::getLike()` drops the WHERE clause when there is no search term, but
`getValues()` returned a `like` value regardless. Binding a parameter the statement has no
token for is an error, so the page every user lands on after logging in died with

```
SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens
```

**This is not new.** It reproduces identically on `4b3c6d4`, before any of the recent security
work. It was unreachable because logging in was itself broken -- the login form had no CSRF
field -- so nothing got to the page. Fixing login is what exposed it.

## Verification

- **216 tests green on PHP 7.4, 8.2, 8.3 and 8.4**, no deprecations (was 163).
- **Driven against a running stack** (nginx + php-fpm + MariaDB 11), not just unit tests:
  log in, land on the records list, search (hit and miss), create a record through the real
  form, view it, open the edit form, delete it, log out, confirm the bounce back to login --
  then `cache:purge` and repeat cold. No exceptions on any page.
- The records-list bug was bisected across every recent commit with **identical config on both
  sides**; an earlier run that seemed to implicate the `%`→LIKE change was wrong, because the
  older commits could not log in at all and so never reached the query.

## Deliberately not included

Also better downstream, but left alone:

- `Collection` -- profirealt-db has 17 more methods (`map`, `filter`, `find`, `sort`, `group`,
  `slice`, `merge`, `diff`, …). Worth taking, but it is its own change.
- `Cache::add()` / `getRecord()` -- set-if-absent that distinguishes a cached null, and
  envelope access that avoids a second read on `CACHE_STATIC`.
- `Application::getIP()` -- present in all five and best left there: it shells out to
  `exec("ifconfig | grep ...")`, returns the *server's* address, and `ifconfig` is not on the
  alpine images.

## Two notes for later

- **Search wildcards are unescaped.** `RecordsQueryBuilder` builds `'%' . $term . '%'` raw, so
  searching for `%` matches every row. Not an injection -- it is parameterised -- but a user
  can widen a search. `Like::contains()` already escapes this correctly; adopting it would
  need `ESCAPE '!'` added to that hand-written SQL.
- **`Cache`'s unserialize allowlist is a landmine for the forks.** `UNSERIALIZE_ALLOWED_CLASSES`
  is safe here because every `Cache::set()` call uses `CACHE_REQUEST`, which never serialises.
  profirealt-db hit this independently and documented why it does *not* restrict `unserialize`:
  its callers store Model and Config instances in the envelope, which an allowlist turns into
  `__PHP_Incomplete_Class` on read. Anything caching entities in `CACHE_SESSION` or
  `CACHE_STATIC` must extend that constant.
